### PR TITLE
v1.11: Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y build-essential \
@@ -22,7 +22,9 @@ RUN apt-get update && \
                        libjansson-dev \
                        zlib1g \
                        librdkafka-dev \
-                       apache2-utils
+                       apache2-utils \
+                       jq \
+                       kafkacat
 
 ADD https://github.com/r4um/jmx-dump/releases/download/0.9.3/jmx-dump-0.9.3-standalone.jar /usr/share/java
 ADD https://github.com/tomnomnom/gron/releases/download/v0.6.0/gron-linux-386-0.6.0.tgz /usr/share/java
@@ -30,15 +32,9 @@ RUN cd /usr/share/java/ && tar -zxf gron-linux-386-0.6.0.tgz && chmod -R a+rx *
 
 RUN groupadd -r testuser && useradd -r -g testuser testuser
 RUN mkdir /home/testuser && chmod a+rw /home/testuser
-ADD http://apache.mirrors.hoobly.com/kafka/2.4.1/kafka_2.12-2.4.1.tgz /home/testuser/
-RUN cd /home/testuser && tar -zxf kafka_2.12-2.4.1.tgz
-RUN cd /home/testuser && \
-    git clone https://github.com/edenhill/kafkacat.git && \
-    cd kafkacat && \
-    ./configure && \
-    make && \
-    make install
+ADD https://mirrors.ocf.berkeley.edu/apache/kafka/2.6.0/kafka_2.13-2.6.0.tgz /home/testuser/
+RUN cd /home/testuser && tar -zxf kafka_2.13-2.6.0.tgz
 
 RUN chown -R testuser /home/testuser
 USER 999
-ENV PATH="${PATH}:/usr/local/bin/:/usr/share/java:/home/testuser/kafka_2.12-2.4.1/bin"
+ENV PATH="${PATH}:/usr/local/bin/:/usr/share/java:/home/testuser/kafka_2.13-2.6.0/bin"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Docker image containing some useful debug/troubleshooting utilities for a shel
 - socat
 - gron
 - jmxdump
-- kafkacat
-- kafka
+- kafkacat (with zstd)
+- kafka 2.13
 - apache2-utils (apachebench etc)
+- jq


### PR DESCRIPTION
- ubuntu 20.10
- kafkacat with zstd now
- kafka 2.13
- adding jq