### PR TITLE
v1.12: Updating kafka to 2.12-2.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ RUN cd /usr/share/java/ && tar -zxf gron-linux-386-0.6.0.tgz && chmod -R a+rx *
 
 RUN groupadd -r testuser && useradd -r -g testuser testuser
 RUN mkdir /home/testuser && chmod a+rw /home/testuser
-ADD https://mirrors.ocf.berkeley.edu/apache/kafka/2.6.0/kafka_2.13-2.6.0.tgz /home/testuser/
-RUN cd /home/testuser && tar -zxf kafka_2.13-2.6.0.tgz
+ADD https://apache.claz.org/kafka/2.8.0/kafka_2.12-2.8.0.tgz /home/testuser/
+RUN cd /home/testuser && tar -zxf kafka_2.12-2.8.0.tgz
 
 RUN chown -R testuser /home/testuser
 USER 999
-ENV PATH="${PATH}:/usr/local/bin/:/usr/share/java:/home/testuser/kafka_2.13-2.6.0/bin"
+ENV PATH="${PATH}:/usr/local/bin/:/usr/share/java:/home/testuser/kafka_2.12-2.8.0/bin"
+WORKDIR /home/testuser

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ A Docker image containing some useful debug/troubleshooting utilities for a shel
 - gron
 - jmxdump
 - kafkacat (with zstd)
-- kafka 2.13
+- kafka 2.12-2.8.0
 - apache2-utils (apachebench etc)
 - jq


### PR DESCRIPTION
setting working directory to testuser home